### PR TITLE
feat: Add monthly calculations and summary stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,32 @@
 # Compound Interest Calculator
 
-A simple web-based compound interest calculator built with HTML, CSS, and JavaScript. This tool helps you visualize the growth of your investment over time based on various factors.
+A simple web-based compound interest calculator built with HTML, CSS, and JavaScript. This tool helps you visualize the growth of your investment over time with monthly contributions and compounding.
 
 ## Features
 
--   **Principal Amount**: The initial amount of money you invest.
--   **Annual Interest Rate**: The annual percentage at which your investment grows.
+-   **Initial Principal Amount**: The initial amount of money you invest.
+-   **Annual Interest Rate**: The annual percentage at which your investment grows. Interest is compounded monthly.
 -   **Investment Period**: The number of years you plan to keep your money invested.
+-   **Monthly Contribution**: A fixed amount you contribute to your investment each month.
+-   **Annual Increase in Monthly Contribution**: The percentage by which your monthly contribution increases each year.
 -   **Reinvest Interest**: A checkbox to choose between compound interest (checked) and simple interest (unchecked).
-    -   **Compound Interest**: Interest is earned on the initial principal and the accumulated interest from previous periods.
+    -   **Compound Interest**: Interest is earned on the current balance.
     -   **Simple Interest**: Interest is earned only on the initial principal amount.
--   **Annual Contribution**: A fixed amount you contribute to your investment each year.
--   **Annual Contribution Increase**: The percentage by which your annual contribution increases each year.
--   **Results Breakdown**: A year-by-year table showing the starting balance, interest earned, annual contribution, and ending balance.
+-   **Results Breakdown**: A year-by-year table showing the starting balance, interest earned, total contributions for the year, and the ending balance.
+-   **Summary Statistics**: A summary including the final balance, total principal invested (initial principal + all contributions), and total interest earned.
 
 ## How to Use
 
 1.  Open the `index.html` file in your web browser.
 2.  Fill in the input fields:
-    -   Principal Amount
+    -   Principal Amount ($)
     -   Annual Interest Rate (%)
     -   Investment Period (Years)
-    -   Annual Contribution ($)
-    -   Annual Contribution Increase (%)
+    -   Monthly Contribution ($)
+    -   Annual Increase in Monthly Contribution (%)
 3.  Check or uncheck the "Reinvest Interest" box based on your preference.
 4.  Click the "Calculate" button.
-5.  The total balance and a detailed year-by-year breakdown will be displayed below.
+5.  The summary statistics and a detailed year-by-year breakdown will be displayed below.
 
 ## Project Structure
 

--- a/index.html
+++ b/index.html
@@ -27,18 +27,22 @@
                 <input type="checkbox" id="reinvest-interest" checked>
             </div>
             <div class="form-group">
-                <label for="annual-contribution">Annual Contribution ($):</label>
-                <input type="number" id="annual-contribution" value="0">
+                <label for="monthly-contribution">Monthly Contribution ($):</label>
+                <input type="number" id="monthly-contribution" value="100">
             </div>
             <div class="form-group">
-                <label for="contribution-increase">Annual Contribution Increase (%):</label>
+                <label for="contribution-increase">Annual Increase in Monthly Contribution (%):</label>
                 <input type="number" id="contribution-increase" value="0">
             </div>
             <button type="submit">Calculate</button>
         </form>
         <div id="result" class="hidden">
             <h2>Results</h2>
-            <p>Total Balance: <span id="total-balance"></span></p>
+            <p><strong>Final Balance: <span id="total-balance"></span></strong></p>
+            <div id="stats">
+                <p>Total Principal Invested: <span id="total-invested"></span></p>
+                <p>Total Interest Earned: <span id="total-interest"></span></p>
+            </div>
             <table id="breakdown-table">
                 <thead>
                     <tr>

--- a/js/script.js
+++ b/js/script.js
@@ -5,50 +5,73 @@ document.getElementById('calculator-form').addEventListener('submit', function(e
 
 function calculate() {
     const principal = parseFloat(document.getElementById('principal').value);
-    const interestRate = parseFloat(document.getElementById('interest-rate').value) / 100;
+    const annualInterestRate = parseFloat(document.getElementById('interest-rate').value) / 100;
     const years = parseInt(document.getElementById('years').value);
     const reinvestInterest = document.getElementById('reinvest-interest').checked;
-    const annualContribution = parseFloat(document.getElementById('annual-contribution').value);
-    const contributionIncrease = parseFloat(document.getElementById('contribution-increase').value) / 100;
+    const monthlyContribution = parseFloat(document.getElementById('monthly-contribution').value);
+    const contributionIncreasePercent = parseFloat(document.getElementById('contribution-increase').value) / 100;
 
-    if (isNaN(principal) || isNaN(interestRate) || isNaN(years) || isNaN(annualContribution) || isNaN(contributionIncrease)) {
+    if (isNaN(principal) || isNaN(annualInterestRate) || isNaN(years) || isNaN(monthlyContribution) || isNaN(contributionIncreasePercent)) {
         alert("Please enter valid numbers in all fields.");
         return;
     }
 
+    const monthlyInterestRate = annualInterestRate / 12;
+    const totalMonths = years * 12;
+
     let currentBalance = principal;
+    let totalInterestEarned = 0;
+    let totalContributions = 0;
+    let currentMonthlyContribution = monthlyContribution;
+
     const breakdownBody = document.getElementById('breakdown-body');
     breakdownBody.innerHTML = ''; // Clear previous results
 
-    let contributionForYear = annualContribution;
+    let yearlyInterest = 0;
+    let yearlyContribution = 0;
+    let yearStartingBalance = principal;
 
-    for (let i = 1; i <= years; i++) {
-        const startingBalance = currentBalance;
+    for (let month = 1; month <= totalMonths; month++) {
+        // Calculate interest for the current month
+        const interestThisMonth = (reinvestInterest ? currentBalance : principal) * monthlyInterestRate;
+        currentBalance += interestThisMonth;
+        totalInterestEarned += interestThisMonth;
+        yearlyInterest += interestThisMonth;
 
-        const interestEarnedThisYear = (reinvestInterest ? currentBalance : principal) * interestRate;
-        currentBalance += interestEarnedThisYear;
-
-        let contributionAdded = 0;
-        if (contributionForYear > 0) {
-            currentBalance += contributionForYear;
-            contributionAdded = contributionForYear;
-            // Increase contribution for the next year
-            contributionForYear *= (1 + contributionIncrease);
+        // Add monthly contribution
+        if (currentMonthlyContribution > 0) {
+            currentBalance += currentMonthlyContribution;
+            totalContributions += currentMonthlyContribution;
+            yearlyContribution += currentMonthlyContribution;
         }
 
-        const endingBalance = currentBalance;
+        // At the end of each year, update the breakdown table and increase the contribution
+        if (month % 12 === 0) {
+            const year = month / 12;
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${year}</td>
+                <td>${yearStartingBalance.toFixed(2)}</td>
+                <td>${yearlyInterest.toFixed(2)}</td>
+                <td>${yearlyContribution.toFixed(2)}</td>
+                <td>${currentBalance.toFixed(2)}</td>
+            `;
+            breakdownBody.appendChild(row);
 
-        const row = document.createElement('tr');
-        row.innerHTML = `
-            <td>${i}</td>
-            <td>${startingBalance.toFixed(2)}</td>
-            <td>${interestEarnedThisYear.toFixed(2)}</td>
-            <td>${contributionAdded.toFixed(2)}</td>
-            <td>${endingBalance.toFixed(2)}</td>
-        `;
-        breakdownBody.appendChild(row);
+            // Reset for next year
+            yearStartingBalance = currentBalance;
+            yearlyInterest = 0;
+            yearlyContribution = 0;
+
+            // Increase the monthly contribution for the next year
+            currentMonthlyContribution *= (1 + contributionIncreasePercent);
+        }
     }
 
+    const totalInvested = principal + totalContributions;
+
     document.getElementById('total-balance').textContent = `$${currentBalance.toFixed(2)}`;
+    document.getElementById('total-invested').textContent = `$${totalInvested.toFixed(2)}`;
+    document.getElementById('total-interest').textContent = `$${totalInterestEarned.toFixed(2)}`;
     document.getElementById('result').classList.remove('hidden');
 }


### PR DESCRIPTION
This commit enhances the compound interest calculator by switching from an annual to a monthly calculation model. It also adds a summary statistics section to provide a more detailed view of the investment's performance.

Changes include:
- The calculation logic now handles monthly contributions and monthly compounding of interest.
- The UI has been updated with fields for monthly contributions.
- A new section displays summary statistics, including total principal invested and total interest earned.
- The README has been updated to reflect the new features.