### PR TITLE
fix: Correct simple interest and reporting logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A simple web-based compound interest calculator built with HTML, CSS, and JavaSc
 -   **Monthly Contribution**: A fixed amount you contribute to your investment each month.
 -   **Annual Increase in Monthly Contribution**: The percentage by which your monthly contribution increases each year.
 -   **Reinvest Interest**: A checkbox to choose between compound interest (checked) and simple interest (unchecked).
-    -   **Compound Interest**: Interest is earned on the current balance.
-    -   **Simple Interest**: Interest is earned only on the initial principal amount.
+    -   **Compound Interest**: Interest is earned on the current balance and is reinvested.
+    -   **Simple Interest**: Interest is earned only on the initial principal amount. This interest is not reinvested and is tracked separately as "Total Encashed Interest".
 -   **Results Breakdown**: A year-by-year table showing the starting balance, interest earned, total contributions for the year, and the ending balance.
--   **Summary Statistics**: A summary including the final balance, total principal invested (initial principal + all contributions), and total interest earned.
+-   **Summary Statistics**: A detailed summary including the final balance, total contributions, total interest earned, and a breakdown of whether that interest was compounded or "encashed" (for simple interest).
 
 ## How to Use
 

--- a/css/style.css
+++ b/css/style.css
@@ -63,8 +63,20 @@ button:hover {
     margin-top: 20px;
 }
 
-#result.hidden {
+.hidden {
     display: none;
+}
+
+#stats {
+    margin-bottom: 20px;
+    padding: 10px;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    background-color: #f9f9f9;
+}
+
+#stats p {
+    margin: 5px 0;
 }
 
 table {

--- a/index.html
+++ b/index.html
@@ -40,8 +40,10 @@
             <h2>Results</h2>
             <p><strong>Final Balance: <span id="total-balance"></span></strong></p>
             <div id="stats">
-                <p>Total Principal Invested: <span id="total-invested"></span></p>
+                <p>Total Contributions Made: <span id="total-invested"></span></p>
                 <p>Total Interest Earned: <span id="total-interest"></span></p>
+                <p id="compounded-interest-p" class="hidden">Compounded Interest: <span id="compounded-interest"></span></p>
+                <p id="encashed-interest-p" class="hidden">Total Encashed Interest: <span id="encashed-interest"></span></p>
             </div>
             <table id="breakdown-table">
                 <thead>

--- a/js/script.js
+++ b/js/script.js
@@ -22,30 +22,40 @@ function calculate() {
     let currentBalance = principal;
     let totalInterestEarned = 0;
     let totalContributions = 0;
+    let totalEncashedInterest = 0;
+    let totalCompoundedInterest = 0;
     let currentMonthlyContribution = monthlyContribution;
 
     const breakdownBody = document.getElementById('breakdown-body');
-    breakdownBody.innerHTML = ''; // Clear previous results
+    breakdownBody.innerHTML = '';
+
+    const encashedInterestP = document.getElementById('encashed-interest-p');
+    const compoundedInterestP = document.getElementById('compounded-interest-p');
+    encashedInterestP.classList.add('hidden');
+    compoundedInterestP.classList.add('hidden');
 
     let yearlyInterest = 0;
     let yearlyContribution = 0;
     let yearStartingBalance = principal;
 
     for (let month = 1; month <= totalMonths; month++) {
-        // Calculate interest for the current month
         const interestThisMonth = (reinvestInterest ? currentBalance : principal) * monthlyInterestRate;
-        currentBalance += interestThisMonth;
         totalInterestEarned += interestThisMonth;
         yearlyInterest += interestThisMonth;
 
-        // Add monthly contribution
+        if (reinvestInterest) {
+            currentBalance += interestThisMonth;
+            totalCompoundedInterest += interestThisMonth;
+        } else {
+            totalEncashedInterest += interestThisMonth;
+        }
+
         if (currentMonthlyContribution > 0) {
             currentBalance += currentMonthlyContribution;
             totalContributions += currentMonthlyContribution;
             yearlyContribution += currentMonthlyContribution;
         }
 
-        // At the end of each year, update the breakdown table and increase the contribution
         if (month % 12 === 0) {
             const year = month / 12;
             const row = document.createElement('tr');
@@ -58,20 +68,28 @@ function calculate() {
             `;
             breakdownBody.appendChild(row);
 
-            // Reset for next year
             yearStartingBalance = currentBalance;
             yearlyInterest = 0;
             yearlyContribution = 0;
 
-            // Increase the monthly contribution for the next year
             currentMonthlyContribution *= (1 + contributionIncreasePercent);
         }
     }
 
     const totalInvested = principal + totalContributions;
+    const finalBalance = currentBalance;
 
-    document.getElementById('total-balance').textContent = `$${currentBalance.toFixed(2)}`;
+    document.getElementById('total-balance').textContent = `$${finalBalance.toFixed(2)}`;
     document.getElementById('total-invested').textContent = `$${totalInvested.toFixed(2)}`;
     document.getElementById('total-interest').textContent = `$${totalInterestEarned.toFixed(2)}`;
+
+    if (reinvestInterest) {
+        document.getElementById('compounded-interest').textContent = `$${totalCompoundedInterest.toFixed(2)}`;
+        compoundedInterestP.classList.remove('hidden');
+    } else {
+        document.getElementById('encashed-interest').textContent = `$${totalEncashedInterest.toFixed(2)}`;
+        encashedInterestP.classList.remove('hidden');
+    }
+
     document.getElementById('result').classList.remove('hidden');
 }


### PR DESCRIPTION
This commit fixes several issues in the calculator's logic related to simple interest calculation and how results are reported.

- The 'Ending Balance' in the yearly breakdown table is now calculated correctly for both simple and compound interest modes.
- The final balance statistic is now accurate and reflects the true state of the account at the end of the investment period.
- A new 'Compounded Interest' statistic has been added, which is displayed when reinvesting is enabled.
- The 'Total Principal Invested' label has been renamed to 'Total Contributions Made' for clarity.