### PR TITLE
feat: Add flexible compounding periods and fix simple interest logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A simple web-based compound interest calculator built with HTML, CSS, and JavaSc
 ## Features
 
 -   **Initial Principal Amount**: The initial amount of money you invest.
--   **Annual Interest Rate**: The annual percentage at which your investment grows. Interest is compounded monthly.
+-   **Interest Rate (% Annum)**: The annual percentage at which your investment grows.
+-   **Compounding Period**: How often the interest is calculated and added to the balance (Monthly, Quarterly, Half-Yearly, Yearly).
 -   **Investment Period**: The number of years you plan to keep your money invested.
 -   **Monthly Contribution**: A fixed amount you contribute to your investment each month.
 -   **Annual Increase in Monthly Contribution**: The percentage by which your monthly contribution increases each year.
@@ -20,7 +21,8 @@ A simple web-based compound interest calculator built with HTML, CSS, and JavaSc
 1.  Open the `index.html` file in your web browser.
 2.  Fill in the input fields:
     -   Principal Amount ($)
-    -   Annual Interest Rate (%)
+    -   Interest Rate (% Annum)
+    -   Compounding Period
     -   Investment Period (Years)
     -   Monthly Contribution ($)
     -   Annual Increase in Monthly Contribution (%)

--- a/css/style.css
+++ b/css/style.css
@@ -33,11 +33,13 @@ h1 {
 }
 
 .form-group input[type="number"],
-.form-group input[type="checkbox"] {
-    width: calc(100% - 22px);
+.form-group input[type="checkbox"],
+.form-group select {
+    width: 100%;
     padding: 10px;
     border: 1px solid #ddd;
     border-radius: 4px;
+    box-sizing: border-box;
 }
 
 .form-group input[type="checkbox"] {

--- a/index.html
+++ b/index.html
@@ -15,8 +15,17 @@
                 <input type="number" id="principal" value="10000" required>
             </div>
             <div class="form-group">
-                <label for="interest-rate">Annual Interest Rate (%):</label>
+                <label for="interest-rate">Interest Rate (% Annum):</label>
                 <input type="number" id="interest-rate" value="5" required>
+            </div>
+            <div class="form-group">
+                <label for="compound-period">Compounding Period:</label>
+                <select id="compound-period">
+                    <option value="12" selected>Monthly</option>
+                    <option value="4">Quarterly</option>
+                    <option value="2">Half-Yearly</option>
+                    <option value="1">Yearly</option>
+                </select>
             </div>
             <div class="form-group">
                 <label for="years">Investment Period (Years):</label>

--- a/js/script.js
+++ b/js/script.js
@@ -4,71 +4,83 @@ document.getElementById('calculator-form').addEventListener('submit', function(e
 });
 
 function calculate() {
+    // --- 1. GET AND PARSE INPUTS ---
     const principal = parseFloat(document.getElementById('principal').value);
     const annualInterestRate = parseFloat(document.getElementById('interest-rate').value) / 100;
     const years = parseInt(document.getElementById('years').value);
     const reinvestInterest = document.getElementById('reinvest-interest').checked;
     const monthlyContribution = parseFloat(document.getElementById('monthly-contribution').value);
     const contributionIncreasePercent = parseFloat(document.getElementById('contribution-increase').value) / 100;
+    const compoundingPeriodsPerYear = parseInt(document.getElementById('compound-period').value);
 
     if (isNaN(principal) || isNaN(annualInterestRate) || isNaN(years) || isNaN(monthlyContribution) || isNaN(contributionIncreasePercent)) {
         alert("Please enter valid numbers in all fields.");
         return;
     }
 
-    const monthlyInterestRate = annualInterestRate / 12;
+    // --- 2. INITIALIZE VARIABLES ---
     const totalMonths = years * 12;
+    const monthsPerCompoundingPeriod = 12 / compoundingPeriodsPerYear;
 
     let currentBalance = principal;
+    let nonCompoundingBalance = principal;
+
     let totalInterestEarned = 0;
     let totalContributions = 0;
-    let totalEncashedInterest = 0;
-    let totalCompoundedInterest = 0;
     let currentMonthlyContribution = monthlyContribution;
 
     const breakdownBody = document.getElementById('breakdown-body');
     breakdownBody.innerHTML = '';
 
-    const encashedInterestP = document.getElementById('encashed-interest-p');
-    const compoundedInterestP = document.getElementById('compounded-interest-p');
-    encashedInterestP.classList.add('hidden');
-    compoundedInterestP.classList.add('hidden');
+    document.getElementById('encashed-interest-p').classList.add('hidden');
+    document.getElementById('compounded-interest-p').classList.add('hidden');
 
     let yearlyInterest = 0;
     let yearlyContribution = 0;
     let yearStartingBalance = principal;
 
+    // --- 3. CALCULATION LOOP ---
     for (let month = 1; month <= totalMonths; month++) {
-        const interestThisMonth = (reinvestInterest ? currentBalance : principal) * monthlyInterestRate;
-        totalInterestEarned += interestThisMonth;
-        yearlyInterest += interestThisMonth;
-
-        if (reinvestInterest) {
-            currentBalance += interestThisMonth;
-            totalCompoundedInterest += interestThisMonth;
-        } else {
-            totalEncashedInterest += interestThisMonth;
-        }
-
+        // Add monthly contribution first
         if (currentMonthlyContribution > 0) {
-            currentBalance += currentMonthlyContribution;
             totalContributions += currentMonthlyContribution;
-            yearlyContribution += currentMonthlyContribution;
+            if (reinvestInterest) {
+                currentBalance += currentMonthlyContribution;
+            } else {
+                nonCompoundingBalance += currentMonthlyContribution;
+            }
         }
 
+        // Calculate and add interest only at the end of a compounding period
+        if (month % monthsPerCompoundingPeriod === 0) {
+            const interestThisPeriod = (reinvestInterest ? currentBalance : principal) * (annualInterestRate / compoundingPeriodsPerYear);
+            totalInterestEarned += interestThisPeriod;
+            yearlyInterest += interestThisPeriod;
+
+            if (reinvestInterest) {
+                currentBalance += interestThisPeriod;
+            }
+        }
+
+        // Accumulate yearly contribution amount for the table display
+        yearlyContribution += currentMonthlyContribution;
+
+        // At the end of each year, update the breakdown table
         if (month % 12 === 0) {
             const year = month / 12;
+            const endingBalanceForYear = reinvestInterest ? currentBalance : nonCompoundingBalance;
+
             const row = document.createElement('tr');
             row.innerHTML = `
                 <td>${year}</td>
                 <td>${yearStartingBalance.toFixed(2)}</td>
                 <td>${yearlyInterest.toFixed(2)}</td>
                 <td>${yearlyContribution.toFixed(2)}</td>
-                <td>${currentBalance.toFixed(2)}</td>
+                <td>${endingBalanceForYear.toFixed(2)}</td>
             `;
             breakdownBody.appendChild(row);
 
-            yearStartingBalance = currentBalance;
+            yearStartingBalance = endingBalanceForYear;
             yearlyInterest = 0;
             yearlyContribution = 0;
 
@@ -76,19 +88,20 @@ function calculate() {
         }
     }
 
+    // --- 4. DISPLAY RESULTS ---
     const totalInvested = principal + totalContributions;
-    const finalBalance = currentBalance;
+    const finalBalance = reinvestInterest ? currentBalance : nonCompoundingBalance + totalInterestEarned;
 
     document.getElementById('total-balance').textContent = `$${finalBalance.toFixed(2)}`;
     document.getElementById('total-invested').textContent = `$${totalInvested.toFixed(2)}`;
     document.getElementById('total-interest').textContent = `$${totalInterestEarned.toFixed(2)}`;
 
     if (reinvestInterest) {
-        document.getElementById('compounded-interest').textContent = `$${totalCompoundedInterest.toFixed(2)}`;
-        compoundedInterestP.classList.remove('hidden');
+        document.getElementById('compounded-interest').textContent = `$${totalInterestEarned.toFixed(2)}`;
+        document.getElementById('compounded-interest-p').classList.remove('hidden');
     } else {
-        document.getElementById('encashed-interest').textContent = `$${totalEncashedInterest.toFixed(2)}`;
-        encashedInterestP.classList.remove('hidden');
+        document.getElementById('encashed-interest').textContent = `$${totalInterestEarned.toFixed(2)}`;
+        document.getElementById('encashed-interest-p').classList.remove('hidden');
     }
 
     document.getElementById('result').classList.remove('hidden');


### PR DESCRIPTION
This commit introduces a major enhancement to the compound interest calculator, allowing users to select different compounding periods. It also includes a critical fix for the simple interest calculation.

New Features:
- A dropdown menu has been added to select the compounding period: Monthly, Quarterly, Half-Yearly, or Yearly.
- The calculation engine has been refactored to support these flexible periods.

Bug Fixes:
- The logic for simple interest (when 'Reinvest Interest' is unchecked) has been corrected to ensure the 'Encashed Interest' is calculated and displayed accurately.
- The final balance and year-by-year breakdown are now correct and less confusing for both simple and compound interest modes.
- UI labels and statistics have been clarified for a better user experience.